### PR TITLE
Fixed ActionMenuItemView issue. Resolves #5

### DIFF
--- a/library/src/main/java/com/afollestad/aesthetic/AestheticActionMenuItemView.java
+++ b/library/src/main/java/com/afollestad/aesthetic/AestheticActionMenuItemView.java
@@ -35,6 +35,8 @@ final class AestheticActionMenuItemView extends ActionMenuItemView {
 
   @Override
   public void setIcon(final Drawable icon) {
+    super.setIcon(icon);
+
     // We need to retrieve the color again here.
     // For some reason, without this, a transparent color is used and the icon disappears
     // when the overflow menu opens.


### PR DESCRIPTION
Call through to super immediately when `setIcon()` is called. Otherwise, the system assumes there is no icon and displays text instead - until Aesthetic returns a new icon from the subsequent Observable.