### PR TITLE
Added MaterialProgressBar to InflationInterceptor

### DIFF
--- a/library/src/main/java/com/afollestad/aesthetic/InflationInterceptor.java
+++ b/library/src/main/java/com/afollestad/aesthetic/InflationInterceptor.java
@@ -165,6 +165,7 @@ final class InflationInterceptor implements LayoutInflaterFactory {
         view = new AestheticSeekBar(context, attrs);
         break;
       case "ProgressBar":
+      case "me.zhanghai.android.materialprogressbar.MaterialProgressBar":
         view = new AestheticProgressBar(context, attrs);
         break;
       case "android.support.v7.view.menu.ActionMenuItemView":


### PR DESCRIPTION
If the MaterialProgressBar is used instead of AestheticProgressBar, ensure that it still gets themed via Aesthetic.