### PR TITLE
Honor aesthetic_ignore tag onResume

### DIFF
--- a/library/src/main/java/com/afollestad/aesthetic/Aesthetic.java
+++ b/library/src/main/java/com/afollestad/aesthetic/Aesthetic.java
@@ -275,10 +275,17 @@ public class Aesthetic {
           instance.backgroundSubscriberViews.get(instance.context.getClass().getName());
       if (pairs != null) {
         for (ViewObservablePair pair : pairs) {
+
+          final View view = pair.view();
+
+          if (view.getTag() != null && view.getTag().equals(":aesthetic_ignore")) {
+            continue;
+          }
+
           instance.backgroundSubscriptions.add(
               pair.observable()
                   .compose(Rx.<Integer>distinctToMainThread())
-                  .subscribeWith(ViewBackgroundSubscriber.create(pair.view())));
+                  .subscribeWith(ViewBackgroundSubscriber.create(view)));
         }
       }
     }


### PR DESCRIPTION
I get in situation where I had an view with `?colorAccent` as default background color in the xml but when I try to override this color dynamically and set `:aesthetic_ignore` tag to this view, when app comes from background it triggers tint of the view with the accent color instead of just ignoring it.